### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github-action-checks.yml
+++ b/.github/workflows/github-action-checks.yml
@@ -1,6 +1,8 @@
 name: GitHub Actions Check
 run-name: ${{ github.actor }} Checks 🚀
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   Link-Format-Checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Rose2161/bips/security/code-scanning/1](https://github.com/Rose2161/bips/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/github-action-checks.yml` so all jobs inherit least-privilege token access.

Best fix (no functional change): define:

```yml
permissions:
  contents: read
```

at the workflow root (after `on` is a common placement). This satisfies `actions/checkout` and keeps all current jobs functioning while preventing unintended write permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
